### PR TITLE
Add support for uvx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "requests>=2.32.3",
 ]
 
+[project.scripts]
+explorium-mcp-server = "explorium_mcp_server.__main__:main"
+
 [dependency-groups]
 dev = [
     "build>=1.2.2.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README-pypi.md"
 requires-python = ">=3.10"
 dependencies = [
     "requests>=2.32.3",
+    "mcp[cli]>=1.3.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Adds some missing things to make sure `uvx explorium-mcp-server` works without cloning the repo.